### PR TITLE
Fix character paused jump

### DIFF
--- a/src/lib/components/Controls.svelte
+++ b/src/lib/components/Controls.svelte
@@ -5,7 +5,6 @@
   let status: typeof Game['status'] = 'idle';
   let show = false;
   $: showControls = ['running', 'pause'].includes(status);
-  $: character = game.character;
 
   game.on('all', ({ event }) => {
     if (event !== 'init') {
@@ -30,14 +29,14 @@
       <button
         type="button"
         class="btn control"
-        on:pointerdown={() => character.jump()}
+        on:pointerdown={() => game.character.jump()}
       >
         &uarr;
       </button>
       <button
         type="button"
         class="btn control"
-        on:pointerdown={() => character.crouch()}
+        on:pointerdown={() => game.character.crouch()}
       >
         &darr;
       </button>

--- a/src/lib/game/character.ts
+++ b/src/lib/game/character.ts
@@ -40,11 +40,15 @@ class Character extends Element {
     this.motionDuration = JUMP_DURATION[isMobile() ? 'mobile' : 'desktop'];
     this.attachListeners();
 
-    game.on('play', () => (this.state = 'intro'));
     game.on('init', () => {
       this.x = game.el.width / 2 - this.width;
       this.y = game.el.height - CHAR_HEIGHT - CHAR_OFFSET_Y;
       this.initial.y = this.y;
+    });
+    game.on('play', () => {
+      if (this.state === 'idle') {
+        this.state = 'intro';
+      }
     });
     game.on('restart', () => {
       this.y = game.el.height - CHAR_HEIGHT - CHAR_OFFSET_Y;

--- a/src/lib/game/game.ts
+++ b/src/lib/game/game.ts
@@ -32,6 +32,8 @@ class Game {
     this.attachListeners();
     this.getHiScore();
 
+    console.log(this.subs)
+
     this.character = config.character;
     this.announcer = config.announcer;
     this.scenery = config.scenery;

--- a/src/lib/game/game.ts
+++ b/src/lib/game/game.ts
@@ -32,8 +32,6 @@ class Game {
     this.attachListeners();
     this.getHiScore();
 
-    console.log(this.subs)
-
     this.character = config.character;
     this.announcer = config.announcer;
     this.scenery = config.scenery;

--- a/src/lib/stores/challenge.ts
+++ b/src/lib/stores/challenge.ts
@@ -1,6 +1,5 @@
 import { get, writable } from 'svelte/store';
-//import { game } from '../game';
-import game from '../game/game';
+import game from '../game';
 import data from '$lib/data/data';
 
 type ChallengeStore = {
@@ -88,7 +87,6 @@ function challengeStore() {
   });
 
   return {
-    /* init, */
     subscribe: store.subscribe,
     set: store.set,
     update: store.update,


### PR DESCRIPTION
Why: 
 - When pausing midway through a character jump and then resuming, the character state gets reset, and doesn't complete the jump.
 - Controls on mobile are broken from the refactor in previous PR.

How: 
 - On play, only reset character state if currently idle.
 - Fix controls.